### PR TITLE
After-pen armor damage reduction

### DIFF
--- a/Ballistics/BallisticController.cs
+++ b/Ballistics/BallisticController.cs
@@ -64,18 +64,23 @@ namespace RealismMod
         public static void CalcAfterPenStats(float actualDurability, float armorClass, float templateDurability, ref float damage, ref float penetration)
         {
             /*
-            TODO: ADD PUBLIC SPREADSHEET FOR REFERENCE
+            SPREADSHEET REFERENCE: https://docs.google.com/spreadsheets/d/1dWDbSsyMoRGRf7d012f3TVzRVyNbT4mTWk-Mkam75vs/edit?usp=sharing
             Examples with default settings (70% reduction w/ 5 falloff scaling):
                 80 pen vs. LVL10 100%   => 70%
                 75 pen vs. LVL7 100%    => 52%
                 80 pen vs. LVL7 100%    => 39%
                 80 pen vs. LVL5 100%    => 14%
             */
-            float maxReductionOnPen = 0.7f;  // TODO: EXPOSE AS CONFIG
-            float overpenFalloffScale = 5;  // TODO: EXPOSE AS CONFIG
+
+            // TODO: Possibly expose these values to the user
+            float maxReductionOnPen = 0.7f;
+            float overpenFalloffScale = 5;
 
             float relativeOverpen = Mathf.Max(penetration / 10 - armorClass, 0f) / 8;
             float overpenFactor = Mathf.Pow(relativeOverpen + 1, -overpenFalloffScale) * maxReductionOnPen;
+
+            // TODO: Test/tweak durability scaling, default linear scaling was kept in place for now
+            //       This currently rewards the player for patching up their plates regularly
             float armorFactor = 1f - (overpenFactor * (actualDurability / templateDurability));
 
             damage *= armorFactor;

--- a/Ballistics/BallisticsPatches.cs
+++ b/Ballistics/BallisticsPatches.cs
@@ -730,15 +730,7 @@ namespace RealismMod
                         Logger.LogWarning("pen before = " + shot.PenetrationPower);
                     }
 
-                    EFTSlot slot;
-                    ArmorSlot softArmorSlot;
-                    float softArmorReduction = 1f;
-                    if ((slot = (armorComponent.Item.CurrentAddress as EFTSlot)) != null && (softArmorSlot = (slot.Slot as ArmorSlot)) != null && softArmorSlot.BluntDamageReduceFromSoftArmor)
-                    {
-   
-                        softArmorReduction = 0.7f;
-                    }
-                    BallisticsController.CalcAfterPenStats(armorComponent.Repairable.Durability, armorComponent.ArmorClass, armorComponent.Repairable.TemplateDurability, ref shot.Damage, ref shot.PenetrationPower, softArmorReduction);
+                    BallisticsController.CalcAfterPenStats(armorComponent.Repairable.Durability, armorComponent.ArmorClass, armorComponent.Repairable.TemplateDurability, ref shot.Damage, ref shot.PenetrationPower);
                 
                     if (Plugin.EnableBallisticsLogging.Value)
                     {
@@ -1019,7 +1011,7 @@ namespace RealismMod
             }
 
             float bluntThrput = __instance.Template.BluntThroughput;
-            float softArmorStatReduction = 1f;
+            float softArmorStatReduction = 1f; // TODO: Check if worth keeping only for bayonet interactions
             EFTSlot slot;
             ArmorSlot softArmorSlot;
             if ((slot = (__instance.Item.CurrentAddress as EFTSlot)) != null && (softArmorSlot = (slot.Slot as ArmorSlot)) != null && softArmorSlot.BluntDamageReduceFromSoftArmor)
@@ -1081,7 +1073,7 @@ namespace RealismMod
                 }
 
                 float actualDurability = Mathf.Max(__instance.Repairable.Durability - totalDuraLoss, 1);
-                BallisticsController.CalcAfterPenStats(actualDurability, __instance.ArmorClass, __instance.Repairable.TemplateDurability, ref damageInfo.Damage, ref damageInfo.PenetrationPower, softArmorStatReduction);
+                BallisticsController.CalcAfterPenStats(actualDurability, __instance.ArmorClass, __instance.Repairable.TemplateDurability, ref damageInfo.Damage, ref damageInfo.PenetrationPower);
             }
             else
             {


### PR DESCRIPTION
After-pen damage calculations take into consideration the class the ammunition is rated for after possible previous penetrations, while providing enough damage reduction on barely-penetrating rounds as to not feel so binary. 

The aim of this change is to make the player consider rounds that specifically aim for overpenetration to deal the full damage, rather than just barely-penetrating rounds that will lose most of their momentum by penetrating the armor plate and getting stopped by the soft backing. This in turn makes high class plates rewarding to run, as they can actually stop a fair bit of damage while with the plate hitboxes it's still possible to deal a lot of damage through the soft armor alone or even around it.

I've provided a spreadsheet and comments in the code as a reference to what to expect from the current (default) values: https://docs.google.com/spreadsheets/d/1dWDbSsyMoRGRf7d012f3TVzRVyNbT4mTWk-Mkam75vs/edit?usp=sharing

Me and my boyfriend with almost 2 years of military experience (and studying things around ballistics in depth) have tested these changes throughout a few dozen raids, so with that here are the
**Testing notes:**
1. Damage reduction felt pretty much on point to what we would expect from higher class armors
2. Tied to this change, it's recommended to also turn down the overdamage modifiers to reasonable values, as shot-out limbs should not spread that much damage, let alone triple the initial amount, we've settled on values: legs 1; arms 0.8; stomach 1.5
3. Ammunition might need a few tweaks, as with the new changes dealt damage will be a lot more fluid. We have found that generally ammunition rated for the next immediate higher class has ~50% kinetic energy loss, in this case it's more towards 40%.
4. Hit zones were not tested with these changes (yet), I would highly recommend putting some sort of a penetration and/or damage breakpoint on the heart hitbox though, as setting it flat-out could result in getting oneshot by a single point of damage from _wherever_.

Disclaimer: The damage once the round penetrates is obviously not fully realistically portrayed, but we think it's as close as it can get without major changes to the existing mechanics and without turning the game into a hospital stay simulator.