### PR TITLE
Fix for potential crash in OnGameStarted patch

### DIFF
--- a/Health/HazardTracker.cs
+++ b/Health/HazardTracker.cs
@@ -124,7 +124,7 @@ namespace RealismMod
         public static bool CanSpawnDynamicZones()
         {
             var sessionData = Singleton<ClientApplication<ISession>>.Instance.GetClientBackEndSession();
-            var dynamicZoneQuest = sessionData.Profile.QuestsData.First(q => q.Id == "66dad1a18cbba6e558486336");
+            var dynamicZoneQuest = sessionData.Profile.QuestsData.FirstOrDefault(q => q.Id == "66dad1a18cbba6e558486336");
             bool didRequiredQuest = false;
             if (dynamicZoneQuest != null) 
             {


### PR DESCRIPTION
Drakia's fix for a potential crash when no matches are found.
-Realism is crashing in its "OnGameStarted" patch, which can cause [other mods' patches] to not run (and the mods to throw exceptions in raid when the relevant variables are accessed).